### PR TITLE
Fix handling data those contain key "entries"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axios-case-converter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "lib/index.js",
   "module": "es/index.js",
   "scripts": {

--- a/src/transform.js
+++ b/src/transform.js
@@ -23,7 +23,7 @@ const transform = (data, fn, overwrite = false) => {
   /* eslint-enable no-console */
 
   const store = overwrite ? data : new data.constructor
-  for (const [key, value] of data.entries ? data.entries(data) : Object.entries(data)) {
+  for (const [key, value] of typeof data.entries === 'function' ? data.entries(data) : Object.entries(data)) {
     if (store.append) {
       store.append(key.replace(/[^[\]]+/g, k => fn(k)), transform(value, fn))
     } else {

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,9 @@ const data = {
     'foo',
     { foo_bar_baz456: 'fooBarBaz456' },
   ],
+  entries: {
+    foo_bar_baz123: 'fooBarBaz123',
+  },
   empty: null,
 }
 
@@ -40,6 +43,9 @@ test('it should be converted on success', assert => {
         'foo',
         { fooBarBaz456: 'fooBarBaz456' },
       ],
+      entries: {
+        fooBarBaz123: 'fooBarBaz123',
+      },
       empty: null,
     },
     {
@@ -61,6 +67,9 @@ test('it should be converted on success', assert => {
         'foo',
         { fooBarBaz456: 'fooBarBaz456' },
       ],
+      entries: {
+        fooBarBaz123: 'fooBarBaz123',
+      },
       empty: null,
     })
     assert.equal(response.headers.contentType, 'application/json')
@@ -88,6 +97,9 @@ test('it should be converted on failure', assert => {
         'foo',
         { fooBarBaz456: 'fooBarBaz456' },
       ],
+      entries: {
+        fooBarBaz123: 'fooBarBaz123',
+      },
       empty: null,
     },
     {
@@ -109,6 +121,9 @@ test('it should be converted on failure', assert => {
         'foo',
         { fooBarBaz456: 'fooBarBaz456' },
       ],
+      entries: {
+        fooBarBaz123: 'fooBarBaz123',
+      },
       empty: null,
     })
     assert.equal(error.response.headers.contentType, 'application/json')


### PR DESCRIPTION
- Fix handling data such as `{entries: {...}}`
- Bump version to 0.2.1