### PR TITLE
Avoid prototype pollution attacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,19 +39,18 @@
     "babel-eslint": "^7.2.3",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "^1.6.0",
+    "babel-preset-env": "^1.7.0",
     "cross-env": "^5.0.5",
     "eslint": "^4.6.1",
     "eslint-plugin-react": "^7.3.0",
     "in-publish": "^2.0.0",
     "npm-run-all": "^4.1.1",
     "redux": "^3.7.2",
-    "tap-spec": "^4.1.1",
+    "tap-spec": "^5.0.0",
     "tape": "^4.8.0",
     "utils-copy-error": "^1.0.1"
   },
   "dependencies": {
-    "change-case": "^3.0.1",
-    "is-plain-object": "^2.0.4"
+    "change-case": "^3.0.1"
   }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,2 +1,3 @@
 export const isURLSearchParams = value => typeof URLSearchParams !== 'undefined' && value instanceof URLSearchParams
 export const isFormData = value => typeof FormData !== 'undefined' && value instanceof FormData
+export const isPlainObject = value => typeof value === 'object' && value !== null && Object.prototype.toString.call(value) === '[object Object]'

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,7 @@ import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import applyConverters from '../src'
 
-const data = {
+const snakeData = {
   user_id: 1,
   something_object: {
     foo_bar_baz123: 'fooBarBaz123',
@@ -14,6 +14,38 @@ const data = {
   ],
   entries: {
     foo_bar_baz123: 'fooBarBaz123',
+  },
+  append: {
+    foo_bar_baz123: 'fooBarBaz123',
+  },
+  constructor: {
+    foo_bar_baz123: 'fooBarBaz123',
+  },
+  prototype: {
+    foo_bar_baz123: 'fooBarBaz123',
+  },
+  empty: null,
+}
+const camelData = {
+  userId: 1,
+  somethingObject: {
+    fooBarBaz123: 'fooBarBaz123',
+  },
+  somethingArray: [
+    'foo',
+    { fooBarBaz456: 'fooBarBaz456' },
+  ],
+  entries: {
+    fooBarBaz123: 'fooBarBaz123',
+  },
+  append: {
+    fooBarBaz123: 'fooBarBaz123',
+  },
+  constructor: {
+    fooBarBaz123: 'fooBarBaz123',
+  },
+  prototype: {
+    fooBarBaz123: 'fooBarBaz123',
   },
   empty: null,
 }
@@ -29,25 +61,12 @@ test('it should be converted on success', assert => {
     assert.equal(config.headers['X-Requested-With'], 'XMLHttpRequest')
     assert.equal(config.params.user_id, 1)
     assert.equal(config.params.screen_name, 'yay')
-    assert.equal(config.data, JSON.stringify(data))
-    return [200, data, {'Content-Type': 'application/json'}]
+    assert.equal(config.data, JSON.stringify(snakeData))
+    return [200, snakeData, {'Content-Type': 'application/json'}]
   })
   client.post(
     '/success',
-    {
-      userId: 1,
-      somethingObject: {
-        fooBarBaz123: 'fooBarBaz123',
-      },
-      somethingArray: [
-        'foo',
-        { fooBarBaz456: 'fooBarBaz456' },
-      ],
-      entries: {
-        fooBarBaz123: 'fooBarBaz123',
-      },
-      empty: null,
-    },
+    camelData,
     {
       headers: {
         xRequestedWith: 'XMLHttpRequest',
@@ -58,20 +77,7 @@ test('it should be converted on success', assert => {
       },
     }
   ).then(response => {
-    assert.deepEqual(response.data, {
-      userId: 1,
-      somethingObject: {
-        fooBarBaz123: 'fooBarBaz123',
-      },
-      somethingArray: [
-        'foo',
-        { fooBarBaz456: 'fooBarBaz456' },
-      ],
-      entries: {
-        fooBarBaz123: 'fooBarBaz123',
-      },
-      empty: null,
-    })
+    assert.equal(JSON.stringify(response.data), JSON.stringify(camelData))
     assert.equal(response.headers.contentType, 'application/json')
     assert.end()
   })
@@ -83,25 +89,12 @@ test('it should be converted on failure', assert => {
     assert.equal(config.headers['X-Requested-With'], 'XMLHttpRequest')
     assert.equal(config.params.user_id, 1)
     assert.equal(config.params.screen_name, 'yay')
-    assert.equal(config.data, JSON.stringify(data))
-    return [400, data, {'Content-Type': 'application/json'}]
+    assert.equal(config.data, JSON.stringify(snakeData))
+    return [400, snakeData, {'Content-Type': 'application/json'}]
   })
   client.post(
     '/failure',
-    {
-      userId: 1,
-      somethingObject: {
-        fooBarBaz123: 'fooBarBaz123',
-      },
-      somethingArray: [
-        'foo',
-        { fooBarBaz456: 'fooBarBaz456' },
-      ],
-      entries: {
-        fooBarBaz123: 'fooBarBaz123',
-      },
-      empty: null,
-    },
+    camelData,
     {
       headers: {
         xRequestedWith: 'XMLHttpRequest',
@@ -112,20 +105,7 @@ test('it should be converted on failure', assert => {
       },
     }
   ).catch(error => {
-    assert.deepEqual(error.response.data, {
-      userId: 1,
-      somethingObject: {
-        fooBarBaz123: 'fooBarBaz123',
-      },
-      somethingArray: [
-        'foo',
-        { fooBarBaz456: 'fooBarBaz456' },
-      ],
-      entries: {
-        fooBarBaz123: 'fooBarBaz123',
-      },
-      empty: null,
-    })
+    assert.equal(JSON.stringify(error.response.data), JSON.stringify(camelData))
     assert.equal(error.response.headers.contentType, 'application/json')
     assert.end()
   })


### PR DESCRIPTION
- Search methods not from object itself but from object prototype.
- Accept objects that have `constructor`, `append` and `prototype` as keys.
- **Avoid `__proto__` pollution attacks.**