### PR TITLE
Allow unconverted params

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,14 @@ export const snakeParams = config => {
   if (config.params) {
     config.params = snake(config.params)
   }
+  
+  if (config.rawParams) {
+    config.parms = {
+      ...config.params,
+      ...config.rawParams
+    }
+  }
+  
   return config
 }
 export const snakeRequest = (data, headers) => {


### PR DESCRIPTION
Love this library, and I'd like to be able to use it with a [django-rest-framework-filters backend](https://github.com/philipn/django-rest-framework-filters).  However, the double__underscore thing it does for filtering breaks on the params filter.

It'd be great to have a way to pass arguments I don't want to send through a case converter.