### PR TITLE
Smaller change case dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "change-case": "^3.0.1"
+    "camel-case": "^4.1.1",
+    "header-case": "^2.0.3",
+    "snake-case": "^3.0.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { header as ccHeader } from 'change-case'
+import { headerCase as ccHeader } from 'header-case'
 import { snake, camel, header } from './transform'
 
 export const snakeParams = config => {

--- a/src/transform.js
+++ b/src/transform.js
@@ -26,7 +26,7 @@ const transform = (data, fn, overwrite = false) => {
     if (prototype && prototype.append) {
       prototype.append.call(store, key.replace(/[^[\]]+/g, k => fn(k)), transform(value, fn))
     } else if (key !== '__proto__') {
-      store[fn(key)] = transform(value, fn)
+      store[fn(typeof key === 'string' ? key : `${key}`)] = transform(value, fn)
     }
   }
   return store

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,8 +1,7 @@
-import {
-  camel as ccCamel,
-  snake as ccSnake,
-  header as ccHeader,
-} from 'change-case'
+import { camelCase as ccCamel } from 'camel-case'
+import { snakeCase as ccSnake } from 'snake-case'
+import { headerCase as ccHeader } from 'header-case'
+
 import { isPlainObject, isURLSearchParams, isFormData } from './util'
 
 const transform = (data, fn, overwrite = false) => {


### PR DESCRIPTION
### Changes
1. Change `change-case@3` to `change-case@4`
2. Import `change-case` functions separately instead of the entire `change-case` module
    - `header-case`
    - `snake-case`
    - `camel-case`
3. Convert non-string input to string before passing it to change-case functions
    - This is done as `change-case@4` no longer handle non string input. Ref: https://github.com/blakeembrey/change-case/issues/69

### Motivation
This PR aims to reduce the size of this package ~~by excluding unused `change-case` methods.~~ (*it turns out the size reduction come [migrating from change-case 3 to 4](https://bundlephobia.com/result?p=change-case@4.1.0)*)

When testing locally, this change is able to reduce `axios-case-converter` bundle size from 33 KB to 6 KB (5.5x reduction)

![Untitled](https://user-images.githubusercontent.com/8733840/71778500-96ac9680-2fe9-11ea-9079-aad985e84cfb.jpg)

Reproduce link: https://github.com/amoshydra/repro-axios-case-converter-pr-15

### Notes:
#### `change-case`'s releases: [change-case](https://github.com/blakeembrey/change-case/releases/tag/change-case%404.0.0), [camel-case](https://github.com/blakeembrey/change-case/releases/tag/camel-case%404.0.0), [header-case](https://github.com/blakeembrey/change-case/releases/tag/header-case%402.0.0), [snake-case](https://github.com/blakeembrey/change-case/releases/tag/snake-case%403.0.0), [no-case](https://github.com/blakeembrey/change-case/releases/tag/no-case%403.0.0)
> #### Changed
> 
> - Function accepts two arguments: string (required) and Options (optional)
> - Default behavior of RegExp is to split on ASCII characters only (previously it used a Unicode RegExp, but this added 5 KB)
> - Function export is renamed to noCase

Notable issue on the changes: https://github.com/blakeembrey/change-case/issues/70