### PR TITLE
🤮 Fix `axios` and `axios-mock-adapter` compatibility issue on tests 🤮 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,17 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # Dirty hacks for https://github.com/mpyw/axios-case-converter/issues/47
+      - name: Disable dirty hacks for old version
+        if: ${{ matrix.axios == '^0' }}
+        uses: "finnp/create-file-action@master"
+        env:
+          FILE_NAME: test/axios-headers-dirty-hacks.ts
+          FILE_DATA: |
+            export function newAxiosHeadersFrom(arg: Record<string, string | string[] | number | boolean | null>): Record<string, string | string[] | number | boolean | null> {
+              return arg
+            }
+
       - name: Test
         run: npm run test:coverage
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,7 @@ jobs:
         node: [18, 16]
         axios:
           - '^0'
-          # TODO: axios v1 are partially supported, and some tests are failing on v1.
-          #       This matrix case will be enabled once the issue is resolved.
-          #       see https://github.com/mpyw/axios-case-converter/issues/47 .
-          # - '^1'
+          - '^1'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,12 @@ jobs:
       # Dirty hacks for https://github.com/mpyw/axios-case-converter/issues/47
       - name: Disable dirty hacks for old version
         if: ${{ matrix.axios == '^0' }}
-        uses: "finnp/create-file-action@master"
-        env:
-          FILE_NAME: test/axios-headers-dirty-hacks.ts
-          FILE_DATA: |
-            export function newAxiosHeadersFrom(arg: Record<string, string | string[] | number | boolean | null>): Record<string, string | string[] | number | boolean | null> {
-              return arg
-            }
+        run: |
+          cat <<EOD > test/axios-headers-dirty-hacks.ts
+          export function newAxiosHeadersFrom(arg: Record<string, string | string[] | number | boolean | null>): Record<string, string | string[] | number | boolean | null> {
+            return arg
+          }
+          EOD
 
       - name: Test
         run: npm run test:coverage

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   rootDir: '.',
   roots: ['<rootDir>/src/', '<rootDir>/test/'],
-  testMatch: ['<rootDir>/test/**/*.ts'],
+  testMatch: ['<rootDir>/test/*/**/*.ts'],
   collectCoverageFrom: ['<rootDir>/src/**/*.ts'],
   resolver: './jest.resolver.js',
 };

--- a/test/axios-headers-dirty-hacks.ts
+++ b/test/axios-headers-dirty-hacks.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosHeaders } from 'axios';
 
+// Dirty hacks for https://github.com/mpyw/axios-case-converter/issues/47
 export function newAxiosHeadersFrom(
   thing?: Record<string, string | string[] | number | boolean | null> | string
 ): AxiosHeaders {

--- a/test/axios-headers-dirty-hacks.ts
+++ b/test/axios-headers-dirty-hacks.ts
@@ -1,0 +1,18 @@
+import axios, { AxiosHeaders } from 'axios';
+
+export function newAxiosHeadersFrom(
+  thing?: Record<string, string | string[] | number | boolean | null> | string
+): AxiosHeaders {
+  let ctor: ReturnType<typeof Object.getPrototypeOf>['constructor'];
+  const client = axios.create();
+  client
+    .get('https://invalid', {
+      transformRequest: [
+        (_, h) => {
+          ctor = Object.getPrototypeOf(h).constructor;
+        },
+      ],
+    })
+    .catch(() => undefined);
+  return new ctor(thing) as AxiosHeaders;
+}

--- a/test/integration/basic.ts
+++ b/test/integration/basic.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import applyCaseMiddleware from '../../src';
+import { newAxiosHeadersFrom } from '../axios-headers-dirty-hacks';
 
 const snakeData = {
   user_id: 1,
@@ -74,10 +75,10 @@ test('it should be converted on success', (done) => {
     return [
       200,
       snakeData,
-      {
+      newAxiosHeadersFrom({
         'Content-Type': 'application/json',
         'THIS-HEADER-SHOULD-BE-PRESERVED': 'preserved',
-      },
+      }),
     ];
   });
   client
@@ -117,10 +118,10 @@ test('it should be converted on failure', (done) => {
     return [
       400,
       snakeData,
-      {
+      newAxiosHeadersFrom({
         'Content-Type': 'application/json',
         'THIS-HEADER-SHOULD-BE-PRESERVED': 'preserved',
-      },
+      }),
     ];
   });
   client


### PR DESCRIPTION
🤮  Fixes #47 🤮 

---

The two critical problems are:

- The value returned from `axios-mock-adapter` mock definitions must be an `AxiosHeaders` object, otherwise the instance reference will be changed.
- `axios` does not expose `AxiosHeaders` constructor.

While not a bug, axios@v1 still has a problem for testability. In this PR, I managed to get the test passed via dirty hacks.