### PR TITLE
fix: 🐛 Don't transform number keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
       matrix:
         node: [18, 16]
         axios:
-          - '^0'
           - '^1'
 
     steps:

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
     "url-search-params-polyfill": "^8.1.1"
   },
   "peerDependencies": {
-    "axios": ">=0.23.0 <2.0.0"
+    "axios": ">=1.0.0 <2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "rollup": "^2.58.0",
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^27.0.5",
-    "typescript": "^4.4.4",
+    "typescript": "^4.9.5",
     "url-search-params-polyfill": "^8.1.1"
   },
   "peerDependencies": {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,18 +3,18 @@ import { isAxiosHeaders, isPlainObject } from './util';
 import {
   ApplyCaseMiddleware,
   AxiosCaseMiddlewareOptions,
-  CreateAxiosInterceptor,
+  CreateAxiosRequestInterceptor,
   CreateAxiosRequestTransformer,
   CreateAxiosResponseTransformer,
   ObjectTransformer,
   TransformableObject,
 } from './types';
 
-export const createSnakeParamsInterceptor: CreateAxiosInterceptor = (
+export const createSnakeParamsInterceptor: CreateAxiosRequestInterceptor = (
   options?
 ) => {
   const { snake } = createObjectTransformers(options?.caseFunctions);
-  return (config): ReturnType<ReturnType<CreateAxiosInterceptor>> => {
+  return (config): ReturnType<ReturnType<CreateAxiosRequestInterceptor>> => {
     if (config.params) {
       config.params = snake(config.params, options);
     }

--- a/src/transformers.ts
+++ b/src/transformers.ts
@@ -105,7 +105,7 @@ const transformObjectUsingCallbackRecursive = (
     if (isFormData(store) || isURLSearchParams(store)) {
       store.append(fn(key as string), value as string & File);
     } else if (key !== '__proto__') {
-      store[fn(typeof key === 'string' ? key : `${key}`)] =
+      store[typeof key === 'number' ? key : fn(`${key}`)] =
         transformObjectUsingCallbackRecursive(value, fn, overwrite);
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ import {
   AxiosRequestConfig,
   AxiosRequestTransformer,
   AxiosResponseTransformer,
+  AxiosRequestHeaders,
+  AxiosInterceptorManager,
 } from 'axios';
 
 /** string transformers (change-case functions) */
@@ -71,11 +73,19 @@ export type AxiosCaseMiddlewareOptions = Omit<
   caseFunctions?: Partial<CaseFunctions>;
   ignoreHeaders?: boolean;
 };
-export interface AxiosInterceptor {
-  (config: AxiosRequestConfig): AxiosRequestConfig;
+export type AxiosInterceptor<V> = NonNullable<
+  Parameters<AxiosInterceptorManager<V>['use']>[0]
+>;
+export type AxiosRequestInterceptor = AxiosInterceptor<
+  AxiosRequestConfig & {
+    headers: AxiosRequestHeaders;
+  }
+>;
+export interface CreateAxiosInterceptor<V> {
+  (options?: AxiosCaseMiddlewareOptions): AxiosInterceptor<V>;
 }
-export interface CreateAxiosInterceptor {
-  (options?: AxiosCaseMiddlewareOptions): AxiosInterceptor;
+export interface CreateAxiosRequestInterceptor {
+  (options?: AxiosCaseMiddlewareOptions): AxiosRequestInterceptor;
 }
 export interface CreateAxiosRequestTransformer {
   (options?: AxiosCaseMiddlewareOptions): AxiosRequestTransformer;
@@ -89,7 +99,7 @@ export type ApplyCaseMiddlewareOptions = AxiosCaseMiddlewareOptions & {
   caseMiddleware?: {
     requestTransformer?: AxiosRequestTransformer;
     responseTransformer?: AxiosResponseTransformer;
-    requestInterceptor?: AxiosInterceptor;
+    requestInterceptor?: AxiosRequestInterceptor;
   };
 };
 export interface ApplyCaseMiddleware {


### PR DESCRIPTION
It might be broken if you customized snake-case functions.

```jsx
const client = applyCaseMiddleware(axios.create(), {
    caseFunctions: {
        snake: (s) => s.replace(/[A-Z]|\d+/g, (s) => `_${s.toLowerCase()}`),
    },
});

cleint.post({ data: ['X', 'Y']});
```

---

The code above actually sends `{"data": []}` instead of  `{"data": ["X", "Y"]}`because it transforms
```js
Array { 0: 'X', 1: 'Y', length: 2 }
```
into
```js
Array { '_0': 'X', '_1': 'Y', length: 2 }
```

