### PR TITLE
added ignoreParams to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ const options = {
 };
 ```
 
+### `ignoreParams`: `boolean`
+
+Disable HTTP URL  parameters transformation.
+
+```js
+const options = {
+  ignoreParams: true
+};
+```
+
 ### `caseFunctions`: `{ snake?: Function, camel?: Function, header?: Function }`
 
 Override built-in `change-case` functions.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -15,7 +15,7 @@ export const createSnakeParamsInterceptor: CreateAxiosRequestInterceptor = (
 ) => {
   const { snake } = createObjectTransformers(options?.caseFunctions);
   return (config): ReturnType<ReturnType<CreateAxiosRequestInterceptor>> => {
-    if (config.params) {
+    if (options?.ignoreParams !== true && config.params) {
       config.params = snake(config.params, options);
     }
     return config;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -15,7 +15,7 @@ export const createSnakeParamsInterceptor: CreateAxiosRequestInterceptor = (
 ) => {
   const { snake } = createObjectTransformers(options?.caseFunctions);
   return (config): ReturnType<ReturnType<CreateAxiosRequestInterceptor>> => {
-    if (options?.ignoreParams !== true && config.params) {
+    if (options?.ignoreParams && config.params) {
       config.params = snake(config.params, options);
     }
     return config;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -15,7 +15,7 @@ export const createSnakeParamsInterceptor: CreateAxiosRequestInterceptor = (
 ) => {
   const { snake } = createObjectTransformers(options?.caseFunctions);
   return (config): ReturnType<ReturnType<CreateAxiosRequestInterceptor>> => {
-    if (options?.ignoreParams && config.params) {
+    if (!options?.ignoreParams && config.params) {
       config.params = snake(config.params, options);
     }
     return config;

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,7 @@ export type AxiosCaseMiddlewareOptions = Omit<
 > & {
   caseFunctions?: Partial<CaseFunctions>;
   ignoreHeaders?: boolean;
+  ignoreParams?: boolean;
 };
 export type AxiosInterceptor<V> = NonNullable<
   Parameters<AxiosInterceptorManager<V>['use']>[0]


### PR DESCRIPTION
Closes #55 

I have added `ignoreParams` options to disable URL parameters transformation.

Before
![image](https://user-images.githubusercontent.com/18068307/225322019-8d02cf20-c063-412e-a5aa-5179dfa2e06f.png)

After(with `ignoreParams` set)
![image](https://user-images.githubusercontent.com/18068307/225321888-2880d783-4b51-4407-b301-c30dcc17f70a.png)

Usage
```ts
applyCaseMiddleware(axioInstace, {
  ignoreParams: true,
});

```