### PR TITLE
fix: Improved isAxiosHeaders validation to handle obfuscated code

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,6 +9,7 @@ import {
   ObjectTransformer,
   TransformableObject,
 } from './types';
+import { AxiosHeaderValue } from 'axios';
 
 export const createSnakeParamsInterceptor: CreateAxiosRequestInterceptor = (
   options?
@@ -74,7 +75,7 @@ const overwriteHeadersOrNoop = (
       headers.delete(key);
       headers.set(
         Object.keys(fn({ [key]: null }, options) as TransformableObject)[0],
-        value,
+        value as AxiosHeaderValue,
         true
       );
     } else {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import { Transformable, TransformableObject } from './types';
+import { AxiosHeaders } from 'axios';
 
 export const isURLSearchParams = (value: unknown): value is URLSearchParams => {
   return (
@@ -27,15 +28,9 @@ export const isTransformable = (value: unknown): value is Transformable => {
   );
 };
 
-// Dirty hack for unexported AxiosHeaders.
-// Don't handle it as Transformable to reduce the scope of the impact.
 export const isAxiosHeaders = (value: unknown): value is AxiosHeaders => {
   if (value == null) {
     return false;
   }
-  return Object.getPrototypeOf(value)?.constructor?.name === 'AxiosHeaders';
+  return value instanceof AxiosHeaders;
 };
-interface AxiosHeaders {
-  set(headerName: string, value: string, rewrite: boolean): unknown;
-  delete(header: string): boolean;
-}


### PR DESCRIPTION
Fixes #59 

However, I've encountered an issue with the UMD build due to axios imports after modifying `util.ts`. To fix it, I added `browser: true` to the `nodeResolve` in `rollup.config.js`. Since I'm not well-versed in rollup configuration, could you provide guidance on the best way to proceed in this situation?

![image](https://github.com/mpyw/axios-case-converter/assets/92136951/6896ea1f-765e-43a9-b66c-3d86cc606700)