### PR TITLE
fix: Mark axios as external dependency in rollup config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,17 @@ Axios transformer/interceptor that converts _snake_case/camelCase_
 
 ### NPM
 
-```
+```bash
 npm install axios-case-converter
 ```
+
+> [!IMPORTANT]
+>
+> Axios is a peer dependency of axios-case-converter and must be installed separately.
+>
+> ```bash
+> npm install axios
+> ```
 
 ### CDN
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,6 +14,9 @@ const config = {
     indent: !isProd,
     exports: 'named',
     file: `dist/axios-case-converter.${isProd ? 'min.js' : 'js'}`,
+    globals: {
+      axios: 'axios',
+    },
   },
   plugins: [
     nodeResolve({
@@ -24,6 +27,7 @@ const config = {
     }),
     isProd && terser(),
   ],
+  external: ['axios'],
 };
 
 export default config;


### PR DESCRIPTION
Fixes #60 UMD bundling issues.

I have updated the Rollup configuration to mark `axios` as an external dependency. This change was necessary to address unresolved dependencies and export errors related to `axios` when bundling the library.

By identifying `axios` as an external dependency, we prevent it from being bundled with this library. This not only reduces the overall bundle size but also mitigates potential conflicts that may arise when different versions of `axios` are utilized in the same application.

Please be aware that consumers of this library will need to have `axios` installed in their project.