### PR TITLE
fix: Pin safe-chain version to v1.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install safe-chain
-        run: curl -fsSL https://raw.githubusercontent.com/AikidoSec/safe-chain/main/install-scripts/install-safe-chain.sh | sh -s -- --ci
+        run: curl -fsSL https://raw.githubusercontent.com/AikidoSec/safe-chain/v1.4.2/install-scripts/install-safe-chain.sh | sh -s -- --ci
+        env:
+          SAFE_CHAIN_VERSION: 1.4.2
 
       - name: Install Packages
         run: npm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,9 @@ jobs:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Install safe-chain
-        run: curl -fsSL https://raw.githubusercontent.com/AikidoSec/safe-chain/main/install-scripts/install-safe-chain.sh | sh -s -- --ci
+        run: curl -fsSL https://raw.githubusercontent.com/AikidoSec/safe-chain/v1.4.2/install-scripts/install-safe-chain.sh | sh -s -- --ci
+        env:
+          SAFE_CHAIN_VERSION: 1.4.2
       - run: npm install
       - run: npm publish
         env:


### PR DESCRIPTION
## Summary
- Pin install script URL to specific tag (`v1.4.2`) instead of `main` branch for security
- Set `SAFE_CHAIN_VERSION` env var to avoid GitHub API rate limiting (403 error)

## Issues Addressed
- Security concern raised in #67 about script tampering risk
- Release workflow failure reported in #68 (403 error from GitHub API)

## Changes
- `.github/workflows/ci.yml`: Pin safe-chain to v1.4.2
- `.github/workflows/release.yml`: Pin safe-chain to v1.4.2

## Test plan
- [ ] CI workflow passes with pinned version
- [ ] Release workflow should now work without 403 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)