### PR TITLE
chore(deps): freeze change-case family at v4 line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,17 @@ updates:
       npm-minor:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # Freeze the change-case family at the current major line.
+      # The v5 line (header-case@3+, camel-case@5+, snake-case@4+, no-case@4+)
+      # is ESM-only and drops the `stripRegexp` option we rely on to preserve
+      # bracketed keys such as `user_profile[screen_name]`. See PR #76.
+      - dependency-name: "header-case"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "camel-case"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "snake-case"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Why

Dependabot proposed bumping `header-case` 2.0.4 → 3.0.0 (#76). That release is part of the **change-case v5** line, which:

- is **ESM-only** (drops CommonJS) — we still ship a CJS build (`lib/index.js`) and want to keep it, and
- **removes the `stripRegexp` option** we depend on. We use `{ stripRegexp: /[^A-Z0-9[\]]+/gi }` to **preserve bracketed keys** like `user_profile[screen_name]` (documented in the README, covered by tests). v5 hardcodes stripping to `/[^\p{L}\d]+/`, which would silently break nested-param keys.

So we freeze the change-case family (`header-case`, `camel-case`, `snake-case`) at the current major line and tell dependabot to stop proposing major bumps for them.

## Change

Adds an `ignore` block for `version-update:semver-major` on the three packages in `.github/dependabot.yml`. Minor/patch updates still flow as before.

Follow-up: #76 will be closed as won't-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)