### PR TITLE
chore(release): v2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "axios-case-converter",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "axios-case-converter",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "camel-case": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axios-case-converter",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",


### PR DESCRIPTION
Re-release of the v2 ESM-only line as **v2.0.1** (same code as the intended 2.0.0).

### Why not 2.0.0
The `v2.0.0` immutable release was deleted, which removed the git tag but left the immutable **"restrict tag creations"** rule on `refs/tags/v2.0.0`. As a result the tag can no longer be recreated (`GH013: Cannot create ref due to creations being restricted`), and npm blocks republishing the unpublished `2.0.0` for 24h. So `2.0.0` is effectively burned; shipping the same tree as `2.0.1`.

Only the version field changes (`package.json` + `package-lock.json`). After merge, tag `v2.0.1` → the release workflow publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)